### PR TITLE
insert-ethers --remove  fails if the host isn't found in the sge config

### DIFF
--- a/src/rocks-command/remove/host/plugin_sge.py
+++ b/src/rocks-command/remove/host/plugin_sge.py
@@ -94,6 +94,7 @@ import os
 import subprocess
 import shlex
 import rocks.commands
+import syslog
 
 class Plugin(rocks.commands.Plugin):
 
@@ -112,6 +113,7 @@ class Plugin(rocks.commands.Plugin):
 		# remove the host from every defined SGE 'host group'
 		#
 		cmd = 'qconf -shgrpl'
+		try:
 		p = subprocess.Popen(shlex.split(cmd), stdin = subprocess.PIPE,
 			stdout = subprocess.PIPE, stderr = subprocess.PIPE)
 
@@ -132,4 +134,6 @@ class Plugin(rocks.commands.Plugin):
 			stdin = subprocess.PIPE,
 			stdout = subprocess.PIPE,
 			stderr = subprocess.PIPE)
+		except:
+                        syslog.syslog(syslog.LOG_INFO, 'sge remove fail for %s' % host)
 

--- a/src/rocks-command/remove/host/plugin_sge.py
+++ b/src/rocks-command/remove/host/plugin_sge.py
@@ -114,26 +114,26 @@ class Plugin(rocks.commands.Plugin):
 		#
 		cmd = 'qconf -shgrpl'
 		try:
-		p = subprocess.Popen(shlex.split(cmd), stdin = subprocess.PIPE,
-			stdout = subprocess.PIPE, stderr = subprocess.PIPE)
+			p = subprocess.Popen(shlex.split(cmd), stdin = subprocess.PIPE,
+				stdout = subprocess.PIPE, stderr = subprocess.PIPE)
 
-		for group in p.stdout.readlines():
-			cmd = 'qconf -dattr hostgroup hostlist %s %s' % \
-				(host, group)
+			for group in p.stdout.readlines():
+				cmd = 'qconf -dattr hostgroup hostlist %s %s' % \
+					(host, group)
 
+				p = subprocess.Popen(shlex.split(cmd),
+					stdin = subprocess.PIPE,
+					stdout = subprocess.PIPE,
+					stderr = subprocess.PIPE)
+
+			#
+			# remove the host as a SGE 'execution host'
+			#
+			cmd = 'qconf -de %s' % host
 			p = subprocess.Popen(shlex.split(cmd),
 				stdin = subprocess.PIPE,
 				stdout = subprocess.PIPE,
 				stderr = subprocess.PIPE)
-
-		#
-		# remove the host as a SGE 'execution host'
-		#
-		cmd = 'qconf -de %s' % host
-		p = subprocess.Popen(shlex.split(cmd),
-			stdin = subprocess.PIPE,
-			stdout = subprocess.PIPE,
-			stderr = subprocess.PIPE)
 		except:
                         syslog.syslog(syslog.LOG_INFO, 'sge remove fail for %s' % host)
 


### PR DESCRIPTION
Don't abort insert-ethers --remove  if the host isn't found in the sge config

Repeat bug by:
   add a new node
   ...some time later, hardware dies
   upgrade cluster and use the upgrade roll
   try to delete the dead node not yet re-added to sge
